### PR TITLE
Fix POM file for the Protege package

### DIFF
--- a/geoxygene-ontology/pom.xml
+++ b/geoxygene-ontology/pom.xml
@@ -41,12 +41,12 @@
 		</dependency>
 
 		<dependency>
-			<groupId>edu.stanford</groupId>
+			<groupId>edu.stanford.protege</groupId>
 			<artifactId>protege</artifactId>
 			<version>3.2.1</version>
 		</dependency>
 		<dependency>
-			<groupId>edu.stanford</groupId>
+			<groupId>edu.stanford.protege</groupId>
 			<artifactId>protege-owl</artifactId>
 			<version>3.2.1</version>
 		</dependency>


### PR DESCRIPTION
I believe this is a fix for the following issue https://github.com/IGNF/geoxygene/issues/43, the path seemed to not be up to date anymore. Source: https://central.sonatype.com/artifact/edu.stanford.protege/protege-owlapi-extensions/4.0.0